### PR TITLE
Basic Nav Bar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,12 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 
+nav:
+  - name: Home
+    link: "/"
+  - name: About
+    link: "/about"
+
 # Build settings
 markdown: kramdown
 theme: jekyll-clf-theme


### PR DESCRIPTION
**Change:** Define a simple nav bar

**Reason:** Clicking on some of the links in the nav bar generates a 404 error. This is because there is no nav bar set in _config.yml so it inherits the nav bar from the theme which has links to many pages not in the template project.

See: 
https://github.com/ubc-cpsc/jekyll-clf-theme/blob/main/_config.yml
```
nav:
  - name: Home
    link: "/"
  - name: About
    link: "/about"
    subnav:
      - name: Contact
        link: "/about/contact"
      - name: Jekyll on Heroku
        link: "/jekyll-on-heroku"
  - name: Help
    link: "/help"
  - name: Nested
    link: "/nested"
    subnav:
      - name: Deep
        link: "/nested/deep"
        subnav:
          - name: Down
            link: "/nested/deep/down"
  - name: Style Guide
    link: styleguide
```

